### PR TITLE
Revise nanosvg and wxwidgets ports

### DIFF
--- a/ports/nanosvg/CMakeLists.txt
+++ b/ports/nanosvg/CMakeLists.txt
@@ -1,8 +1,8 @@
 cmake_minimum_required(VERSION 3.11)
-project(nanosvg C)
+project(nanosvg NONE)
 
 set(NANOSVG_HEADERS src/nanosvg.h src/nanosvgrast.h)
-add_library(nanosvg INTERFACE ${NANOSVG_HEADERS})
+add_library(nanosvg INTERFACE)
 
 set_target_properties(nanosvg PROPERTIES PUBLIC_HEADER "${NANOSVG_HEADERS}")
 
@@ -11,10 +11,6 @@ install(TARGETS nanosvg
   PUBLIC_HEADER DESTINATION include)
 
 install(EXPORT nanosvgTargets
-  FILE nanosvgTargets.cmake
-  NAMESPACE unofficial::
-  DESTINATION share/nanosvg)
-
-install(FILES
-  ${CMAKE_CURRENT_SOURCE_DIR}/nanosvgConfig.cmake
-  DESTINATION share/nanosvg)
+  FILE unofficial-nanosvg-config.cmake
+  NAMESPACE unofficial::nanosvg::
+  DESTINATION share/unofficial-nanosvg)

--- a/ports/nanosvg/nanosvgConfig.cmake
+++ b/ports/nanosvg/nanosvgConfig.cmake
@@ -1,1 +1,0 @@
-include(${CMAKE_CURRENT_LIST_DIR}/nanosvgTargets.cmake)

--- a/ports/nanosvg/portfile.cmake
+++ b/ports/nanosvg/portfile.cmake
@@ -6,15 +6,10 @@ vcpkg_from_github(
     HEAD_REF master
 )
 
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt DESTINATION ${SOURCE_PATH})
-file(COPY ${CMAKE_CURRENT_LIST_DIR}/nanosvgConfig.cmake DESTINATION ${SOURCE_PATH})
+file(COPY "${CMAKE_CURRENT_LIST_DIR}/CMakeLists.txt" DESTINATION "${SOURCE_PATH}")
 
-vcpkg_cmake_configure(
-    SOURCE_PATH ${SOURCE_PATH}
-)
-
+set(VCPKG_BUILD_TYPE "release") # header-only
+vcpkg_cmake_configure(SOURCE_PATH "${SOURCE_PATH}")
 vcpkg_cmake_install()
 
-file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug")
-
-file(INSTALL ${SOURCE_PATH}/LICENSE.txt DESTINATION ${CURRENT_PACKAGES_DIR}/share/${PORT} RENAME copyright)
+file(INSTALL "${SOURCE_PATH}/LICENSE.txt" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${PORT}" RENAME copyright)

--- a/ports/nanosvg/vcpkg.json
+++ b/ports/nanosvg/vcpkg.json
@@ -8,10 +8,6 @@
     {
       "name": "vcpkg-cmake",
       "host": true
-    },
-    {
-      "name": "vcpkg-cmake-config",
-      "host": true
     }
   ]
 }

--- a/ports/wxwidgets/nanosvg-ext-depend.patch
+++ b/ports/wxwidgets/nanosvg-ext-depend.patch
@@ -2,16 +2,13 @@ diff --git a/build/cmake/init.cmake b/build/cmake/init.cmake
 index 8c9275974f..3758261299 100644
 --- a/build/cmake/init.cmake
 +++ b/build/cmake/init.cmake
-@@ -615,3 +615,9 @@ if(wxBUILD_PRECOMP)
+@@ -615,3 +615,6 @@ if(wxBUILD_PRECOMP)
          wx_option_force_value(wxBUILD_PRECOMP OFF)
      endif()
  endif(wxBUILD_PRECOMP)
 +
-+find_package(nanosvg CONFIG REQUIRED)
-+
-+if(NANOSVG_FOUND)
-+    list(APPEND wxTOOLKIT_LIBRARIES unofficial::nanosvg)
-+endif()
++find_package(unofficial-nanosvg CONFIG REQUIRED)
++list(APPEND wxTOOLKIT_LIBRARIES unofficial::nanosvg::nanosvg)
 diff --git a/src/generic/bmpsvg.cpp b/src/generic/bmpsvg.cpp
 index 76f20dce4c..7a7c24b4dd 100644
 --- a/src/generic/bmpsvg.cpp
@@ -21,7 +18,7 @@ index 76f20dce4c..7a7c24b4dd 100644
  // and update the corresponding submodule.
  #ifdef __has_include
 -    #if ! __has_include("../../3rdparty/nanosvg/src/nanosvg.h")
-+    #if ! __has_include(<nanosvg.h>)
++    #if 0
          #error You need to run "git submodule update --init 3rdparty/nanosvg".
          #undef wxHAS_SVG
      #endif

--- a/ports/wxwidgets/portfile.cmake
+++ b/ports/wxwidgets/portfile.cmake
@@ -29,6 +29,12 @@ These development packages can be installed on Ubuntu systems via
     endforeach()
 endif()
 
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        sound   wxUSE_SOUND
+)
+
 set(OPTIONS "")
 if(VCPKG_TARGET_IS_OSX)
     list(APPEND OPTIONS -DCOTIRE_MINIMUM_NUMBER_OF_TARGET_SOURCES=9999)
@@ -73,6 +79,7 @@ endif()
 vcpkg_cmake_configure(
     SOURCE_PATH "${SOURCE_PATH}"
     OPTIONS
+        ${FEATURE_OPTIONS}
         -DwxUSE_REGEX=sys
         -DwxUSE_ZLIB=sys
         -DwxUSE_EXPAT=sys

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -31,9 +31,22 @@
     },
     "zlib"
   ],
+  "default-features": [
+    "sound"
+  ],
   "features": {
     "example": {
       "description": "Example source code and CMake project"
+    },
+    "sound": {
+      "description": "",
+      "dependencies": [
+        {
+          "name": "sdl2",
+          "default-features": false,
+          "platform": "!windows & !osx"
+        }
+      ]
     }
   }
 }

--- a/ports/wxwidgets/vcpkg.json
+++ b/ports/wxwidgets/vcpkg.json
@@ -39,7 +39,7 @@
       "description": "Example source code and CMake project"
     },
     "sound": {
-      "description": "",
+      "description": "Build wxSound support",
       "dependencies": [
         {
           "name": "sdl2",


### PR DESCRIPTION
## nanosvg
Trims the build.
Changes the installation layout for the cmake config so that it is found with package name `unofficial-nanosvg`, corresponding with a full prefix of `unofficial::nanosvg::`.

## wxwidgets
Makes the usage of the external `unofficial-nanosvg` strictly mandatory.
Adds an opt-out "sound" feature and its sdl2 dependency for linux.